### PR TITLE
Check zipcodes are valid before calculating distance.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ exports.lookupByName = byName;
 var dist = function(zipA, zipB) {
     zipA = lookup(zipA);
     zipB = lookup(zipB);
+    if(!zipA || !zipB) return null;
 
     var distance = Math.sin(deg2rad(zipA.latitude)) 
                 * Math.sin(deg2rad(zipB.latitude)) 


### PR DESCRIPTION
I ran into a problem with calculating distance if one of the zipcodes are invalid (happens with user supplied data).  This PR will prevent the program from crashing and simply return null for the distance.