### PR TITLE
Fix radius result for invalid / unmatched zip code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -79,7 +79,9 @@ exports.distance = dist;
 //This is SLLOOOOWWWWW
 exports.radius = function(zip, miles, full) {
     var ret = [], i, d;
-    
+    // Validate zip before scanning
+    if (!lookup(zip))
+        return [];
     for (i in codes.codes) {
         if (dist(zip, i) <= miles) {
             ret.push(((full) ? codes.codes[i] : i));


### PR DESCRIPTION
Currently an invalid zip code returns ALL zip codes in the response, which is confusing.